### PR TITLE
Don't requeue successful records.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    px-kinesis-client (0.0.15)
+    px-kinesis-client (0.0.16)
       aws-sdk (~> 2.0.0)
       circuit_breaker (~> 1.1)
       msgpack

--- a/lib/px/service/kinesis/base_request.rb
+++ b/lib/px/service/kinesis/base_request.rb
@@ -66,6 +66,8 @@ module Px::Service::Kinesis
           tmp_buffer = []
           if response[:failed_record_count] > 0
             response[:records].each_with_index do |r, index|
+              next unless r.error_code
+
               if r.error_code == Aws::Kinesis::Errors::ProvisionedThroughputExceededException.code
                 # set last throughput limited value
                 @last_throughput_exceeded = Time.now

--- a/lib/px/service/kinesis/version.rb
+++ b/lib/px/service/kinesis/version.rb
@@ -1,7 +1,7 @@
 module Px
   module Service
     module Kinesis
-      VERSION = "0.0.15"
+      VERSION = "0.0.16"
     end
   end
 end


### PR DESCRIPTION
Previously if there were any failed records in a batch all records in
the batch were requeued. This led to many duplicates in the Kinesis
stream. This fixes this problem to instead only requeue the failed
records.

@mwstobo https://app.asana.com/0/191296555608986/211487888617068